### PR TITLE
feat: remove colon from getFormattedAddress

### DIFF
--- a/projects/ngx-vcard/src/lib/ngx-vcard.formatter.ts
+++ b/projects/ngx-vcard/src/lib/ngx-vcard.formatter.ts
@@ -261,7 +261,6 @@ function getFormattedPhoto(
 function getFormattedAddress(address: Address) {
   return (
     (address.label ? ';LABEL="' + e(address.label) + '"' : '') +
-    ':' +
     e(address.postOfficeBox) +
     ';' +
     e(address.extendedAddress) +


### PR DESCRIPTION
Hi Daniel! 
I encountered that when I am creating a vCard (version 3.0) that in the address section an extra colon was added. I removed it from the getFormattedAdress-Function and it seems to work out well now. 
Let me know if you have any doubts.

Cheers and thanks for the great package.